### PR TITLE
Separate typeMessage & thisMessage

### DIFF
--- a/locales/pt-BR.js
+++ b/locales/pt-BR.js
@@ -285,6 +285,7 @@ module.exports = {
     new: "(nova)",
     referencedIn: "discussão referida em",
     removedVote: "voto retirado",
+    thisMessage: "esta mensagem",
     typeMessage: "\"%{type}\" mensagem",
     unfollowed: "sem seguir",
   },

--- a/locales/pt-PT.js
+++ b/locales/pt-PT.js
@@ -286,6 +286,7 @@ module.exports = {
     referencedIn: "discussão referida em",
     removedVote: "voto retirado",
     thisMessage: "esta mensagem",
+    typeMessage: "\"%{type}\" mensagem",
     unfollowed: "sem seguir",
   },
   msgs: {


### PR DESCRIPTION
I added a string that I missed when collecting the strings earlier. "\"%{type}\" message". (`msg.typeMessage`).

@tiagocpontesp, are the translations here correct for `msg.typeMessage` and `msg.thisMessage`?
